### PR TITLE
Minor styling adjustments on landing page

### DIFF
--- a/src/components/DSIndex.vue
+++ b/src/components/DSIndex.vue
@@ -45,6 +45,10 @@ const filteredIndex = computed(() => {
 
 <style scoped>
 
+a {
+    font-weight: 700;
+}
+
 div.search_results {
     margin-top: 20px;
 }
@@ -69,6 +73,7 @@ ul.stac_listing > li {
 ul.authors > li {
     display: inline-block;
     margin: 0 .1em;
+    font-size: smaller;
 }
 
 ul.authors > li:nth-last-child(n + 3)::after  {

--- a/src/components/IPFSStatus.vue
+++ b/src/components/IPFSStatus.vue
@@ -7,7 +7,7 @@ const {loading, helia, error, inBrowser} = useHelia();
 
 <template>
     <div class="ipfsstatus">
-        <IpfsLogo width="1.3em" height="1.3em" viewBox="0 0 169 196" style="vertical-align: bottom; display: inline-block;"/> IPFS
+        <a target="_blank" href="https://ipfs.tech"><IpfsLogo width="1.3em" height="1.3em" viewBox="0 0 169 196" style="vertical-align: bottom; display: inline-block;" alt="IPFS"/></a>
         <span v-if="loading" class="tooltip left" data-tip="loading">⏳</span>
         <span v-if="helia" class="tooltip left" data-tip="available">✅</span>
         <span v-if="error" class="tooltip left" :data-tip="error">❌</span>


### PR DESCRIPTION
This PR:
* emphasises the dataset titles (by making them bold)
* tones down the authors (by making them smaller)
* removes the "IPFS" text and adds an external link to the logo

This is just a collection of minor tweaks that seem to improve the overall look of the landing page (subjectively)