### PR TITLE
Apply ORCESTRA color palette to CSS

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ const ds_url = ref("http://127.0.0.1:8080/ipns/latest.orcestra-campaign.org/prod
   font-family: Aileron;
   font-weight: 500;
   font-size: 40px;
-  color: var(--orcestra-blue);
+  color: var(--orcestra-blue-dark);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -37,4 +37,9 @@ input[type="search"] {
     color: var(--fg-color);
     font-size: larger;
 }
+
+input[type="search"]:focus, textarea:focus {
+  outline: solid var(--orcestra-yellow);
+  outline-offset: 2px;
+}
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -151,7 +151,7 @@ a:hover {
 @media (prefers-color-scheme: dark) {
   :root {
     --fg-color: rgba(255, 255, 255, 0.87);
-    --bg-color: #24242;
+    --bg-color: #151515;
     --highlight-bg-color: #444;
   }
   a:hover {

--- a/src/style.css
+++ b/src/style.css
@@ -134,7 +134,10 @@ button:focus-visible {
   --fg-color: #213547;
   --bg-color: #ffffff;
   --highlight-bg-color: #eee;
-  --orcestra-blue: #00267f;
+  --orcestra-blue-dark: #00267f;
+  --orcestra-blue-medium: #6d88bc;
+  --orcestra-blue-light: #a3b4d8;
+  --orcestra-yellow: #ffc726;
 }
 
 a {

--- a/src/style.css
+++ b/src/style.css
@@ -141,11 +141,11 @@ button:focus-visible {
 }
 
 a {
-  color: #646cff;
+  color: var(--orcestra-blue-dark);
 }
 
 a:hover {
-  color: #747bff;
+  color: var(--orcestra-blue-medium);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -156,5 +156,12 @@ a:hover {
   }
   a:hover {
     color: #535bf2;
+  }
+  a {
+    color: var(--orcestra-blue-medium);
+  }
+
+  a:hover {
+    color: var(--orcestra-blue-light);
   }
 }


### PR DESCRIPTION
This PR adds a few more colors from the ORCESTRA palette in order to
* homogenise the colors used (especially the blues)
* make the search box stand out
* give the data browser a more official "ORCESTRA look"