### PR TITLE
Revise leaflet map component

### DIFF
--- a/src/components/StacMap.vue
+++ b/src/components/StacMap.vue
@@ -2,7 +2,7 @@
 
 import "leaflet/dist/leaflet.css";
 import { LGeoJson, LMap, LTileLayer } from "@vue-leaflet/vue-leaflet";
-import { computed, ref } from "vue";
+import { computed, ref, onMounted, onUnmounted } from "vue";
 
 const { item } = defineProps<{ item: StacItem }>();
 
@@ -20,15 +20,25 @@ const onMapReady = (mapObject) => {
   }
 };
 
+const mediaQuery = window.matchMedia('(prefers-color-scheme : dark)');
+const isDarkMode = ref(mediaQuery.matches);
+
+const update = (event) => (isDarkMode.value = event.matches);
+onMounted(() => mediaQuery.addEventListener("change", update));
+onUnmounted(() => mediaQuery.removeEventListener("change", update));
+
+const url = computed(() => `https://tiles.stadiamaps.com/tiles/alidade_smooth${isDarkMode.value ? '_dark' : ''}/{z}/{x}/{y}{r}.png`);
+
 </script>
 
 <template>
     <div class="map" v-if="item.bbox">
         <LMap ref="map" :center="mapCenter" :use-global-leaflet="false" @ready="onMapReady">
         <LTileLayer
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            :url="url"
             layer-type="base"
-            name="OpenStreetMap"
+            name="Stadia Maps"
+            attribution='&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a>'
         ></LTileLayer>
         <LGeoJson :geojson="item" :options-style="style"/>
         </LMap>

--- a/src/components/StacMap.vue
+++ b/src/components/StacMap.vue
@@ -6,7 +6,7 @@ import { computed, ref, onMounted, onUnmounted } from "vue";
 
 const { item } = defineProps<{ item: StacItem }>();
 
-const style = { color: "#3388ff"};
+const style = { color: "var(--line-color)" };
 
 const mapBounds = computed(() => [[item?.bbox[1], item?.bbox[0]], [item?.bbox[3], item?.bbox[2]]]);
 const mapCenter = computed(() => [(item?.bbox[1] + item?.bbox[3]) / 2, (item?.bbox[0] + item?.bbox[2]) / 2]);
@@ -44,3 +44,15 @@ const url = computed(() => `https://tiles.stadiamaps.com/tiles/alidade_smooth${i
         </LMap>
     </div>
 </template>
+
+<style>
+:root {
+  --line-color: var(--orcestra-blue-dark);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --line-color: var(--orcestra-yellow);
+  }
+}
+</style>


### PR DESCRIPTION
This PR adds the following changes:
* change the tile provider to [Stadia Maps](http://stadiamaps.com) (provides dark and light themed maps)
* switch between dark and light map theme depending on user preference
* change the line color of the trajectories depending on the map theme