### PR TITLE
load stac items incrementally

### DIFF
--- a/cli/scanMetadata.ts
+++ b/cli/scanMetadata.ts
@@ -27,6 +27,7 @@ import commandLineUsage from "command-line-usage";
 
 import { registry } from "zarrita";
 import { DeltaCodec } from "../src/utils/ds/codecs/delta.ts";
+import { StacItem } from "../src/utils/stac.ts";
 
 // @ts-expect-error DeltaCodec only handles numbers, but I didn't yet figure out how to check this properly
 registry.set("delta", () => DeltaCodec);
@@ -244,10 +245,14 @@ const stacItems = await Promise.all(
       root_cid,
       item_cid: cid,
     };
-    const stacItem = await parseMetadata(metadata);
-    console.log(stacItem.properties?.title);
+
+    let stacItem;
+    for await (const item of parseMetadata(metadata)) {
+      stacItem = item;
+    }
+    console.log(stacItem?.properties?.title);
     clearTimeout(timeout);
-    return stacItem;
+    return stacItem as StacItem;
   }),
 );
 

--- a/src/components/DSContainer.vue
+++ b/src/components/DSContainer.vue
@@ -26,7 +26,7 @@ const heliaProvider = useHelia();
 
 const metadata: Ref<DatasetMetadata | undefined> = shallowRef();
 
-const stac_item = ref();
+const stac_item = shallowRef();
 
 const update = async () => {
     if (heliaProvider.loading.value) return;
@@ -50,7 +50,9 @@ const update = async () => {
         console.log("IPNS resolve", props.src, item_cid?.toString());
     }
     console.log(metadata.value);
-    stac_item.value = await parseMetadata(unref(metadata));
+    for await (const item of parseMetadata(unref(metadata))) {
+        stac_item.value = item;
+    }
 };
 
 onBeforeMount(update);

--- a/src/components/ItemView.vue
+++ b/src/components/ItemView.vue
@@ -8,36 +8,36 @@ import VarTable from './VarTable.vue';
 import type { StacItem } from '../utils/stac';
 import StacMap from './StacMap.vue';
 
-const props = defineProps<{ item: StacItem }>();
+const {item} = defineProps<{ item: StacItem }>();
 
 const code = computed(() => `import xarray as xr
 
-xr.open_dataset("${ props?.item?.assets?.data?.href }", engine="zarr")`)
+xr.open_dataset("${ item?.assets?.data?.href }", engine="zarr")`)
 
 </script>
 
 <template>
     <div class="head">
-        <h1 class="title">{{ props.item.properties?.title }}</h1>
+        <h1 class="title">{{ item.properties?.title }}</h1>
         <div class="aux">
             <div class="col">
-                <div class="authors"><ul><li v-for="contact in props.item.properties?.contacts">{{ contact.name ?? contact.organization }}</li></ul></div>
-                <div class="time" v-if="props.item?.properties?.start_datetime && props.item?.properties?.end_datetime">{{ props.item.properties.start_datetime }} - {{ props.item.properties.end_datetime }}</div>
-                <div class="time" v-else-if="props.item?.properties?.datetime">{{ props.item.properties.datetime }}</div>
-                <div class="keywords" v-if="props.item?.properties?.keywords"><ul><li v-for="kw in props.item.properties.keywords">{{ kw }}</li></ul></div>
+                <div class="authors"><ul><li v-for="contact in item.properties?.contacts">{{ contact.name ?? contact.organization }}</li></ul></div>
+                <div class="time" v-if="item?.properties?.start_datetime && item?.properties?.end_datetime">{{ item.properties.start_datetime }} - {{ item.properties.end_datetime }}</div>
+                <div class="time" v-else-if="item?.properties?.datetime">{{ item.properties.datetime }}</div>
+                <div class="keywords" v-if="item?.properties?.keywords"><ul><li v-for="kw in item.properties.keywords">{{ kw }}</li></ul></div>
             </div>
-            <div class="col"><License :spdx="props.item?.properties?.license" /></div>
+            <div class="col"><License :spdx="item?.properties?.license" /></div>
         </div>
     </div>
 
     <div class="description">
-        <div class="summary" v-if="props.item.properties?.description">
+        <div class="summary" v-if="item.properties?.description">
             <VMarkdownView
                 mode="view"
-                :content="props.item.properties.description"
+                :content="item.properties.description"
             ></VMarkdownView>
         </div>
-        <StacMap :item="props.item" />
+        <StacMap :item="item" />
     </div>
 
     <div>
@@ -46,12 +46,12 @@ xr.open_dataset("${ props?.item?.assets?.data?.href }", engine="zarr")`)
 
     <h2>Parameter(s)</h2>
     <div>
-        <VarTable :item="props.item" />
+        <VarTable :item="item" />
     </div>
 
-    <div v-if="props.item?.properties?.references">
+    <div v-if="item?.properties?.references">
         <h2>References:</h2>
-        <div class="references"><ul><li v-for="ref in props.item.properties?.references">{{ ref }}</li></ul></div>
+        <div class="references"><ul><li v-for="ref in item.properties?.references">{{ ref }}</li></ul></div>
     </div>
 
 </template>

--- a/src/components/StacMap.vue
+++ b/src/components/StacMap.vue
@@ -40,7 +40,7 @@ const url = computed(() => `https://tiles.stadiamaps.com/tiles/alidade_smooth${i
             name="Stadia Maps"
             attribution='&copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>'
         ></LTileLayer>
-        <LGeoJson :geojson="item" :options-style="style"/>
+        <LGeoJson :geojson="item" :options-style="() => style"/>
         </LMap>
     </div>
 </template>


### PR DESCRIPTION
This change implements parseMetadata as an asynchronous generator, which yields incrementally improved versions of the stac item, as soon as necessary information is available. The last stac item yielded by the generator is the complete item. This can be used to show a partial stac item as soon as anything is available.