### PR TITLE
Minor CSS tweaks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,6 +21,10 @@ const ds_url = ref("http://127.0.0.1:8080/ipns/latest.orcestra-campaign.org/prod
   font-weight: 500;
   font-size: 40px;
   color: var(--orcestra-blue-dark);
+  display: block;
+  line-height: 1;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/components/VarTable.vue
+++ b/src/components/VarTable.vue
@@ -25,7 +25,6 @@ const {item} = defineProps<{ item: StacItem }>();
 .vartable {
   display: flex;
   flex-direction: column;
-  margin-bottom: 5px;
 }
 
 .row {

--- a/src/style.css
+++ b/src/style.css
@@ -67,7 +67,7 @@ a {
 }
 
 body {
-  margin: 0;
+  margin: 0 5px 5px 5px;
   display: flex;
   /*place-items: center;*/
   min-width: 320px;


### PR DESCRIPTION
This PR:
* improves the behaviour of the brand title when line breaks occur on small screens
* adds a small margin around the entire body

I am not sure if the `margin: 0;` was a deliberate choice. I am also fine with keeping it as is, but I find it a bit dense on small screens.