### PR TITLE
Minor adjustments to the styling of item titles

### DIFF
--- a/src/components/ItemView.vue
+++ b/src/components/ItemView.vue
@@ -65,6 +65,13 @@ xr.open_dataset("${ item?.assets?.data?.href }", engine="zarr")`)
     margin: 0;
 }
 
+.title {
+  font-family: "Roboto Slab";
+  font-size: 42px;
+  line-height: 1.1;
+  letter-spacing: -0.25px;
+}
+
 .authors ul {
     list-style: none;
     margin: 0;

--- a/src/components/ItemView.vue
+++ b/src/components/ItemView.vue
@@ -70,6 +70,7 @@ xr.open_dataset("${ item?.assets?.data?.href }", engine="zarr")`)
   font-size: 42px;
   line-height: 1.1;
   letter-spacing: -0.25px;
+  margin: 0.5em 0;
 }
 
 .authors ul {

--- a/src/style.css
+++ b/src/style.css
@@ -85,7 +85,7 @@ nav ._end {
 
 h1 {
   font-family: "Roboto Slab";
-  font-size: 3em;
+  font-size: 42px;
   line-height: 1.1;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -83,13 +83,6 @@ nav ._end {
   margin-left: auto;
 }
 
-h1 {
-  font-family: "Roboto Slab";
-  font-size: 42px;
-  line-height: 1.1;
-  letter-spacing: -0.25px;
-}
-
 button {
   border-radius: 8px;
   border: 1px solid transparent;

--- a/src/style.css
+++ b/src/style.css
@@ -87,6 +87,7 @@ h1 {
   font-family: "Roboto Slab";
   font-size: 42px;
   line-height: 1.1;
+  letter-spacing: -0.25px;
 }
 
 button {


### PR DESCRIPTION
This PR:
* adds a dedicated class to style item titles (`h1` seemed too broad and isn't used anywhere)
* makes the title a bit smaller and a bit denser
* reduces the vertical margin around the title

In general, the changes aim to make the visual appearance of the title more consistent with the other elements.