### PR TITLE
Fix minor CSS spacing issues

### DIFF
--- a/src/components/ItemView.vue
+++ b/src/components/ItemView.vue
@@ -168,7 +168,6 @@ const references = computed(() => parseReferences(item.properties?.references ??
 
 .map {
     max-width: 100%;
-    /*width: 400px;*/
     height: 300px;
     flex: 1 1 400px;
     margin: 5px 0;

--- a/src/components/ItemView.vue
+++ b/src/components/ItemView.vue
@@ -144,7 +144,7 @@ const references = computed(() => parseReferences(item.properties?.references ??
     font-size: 12px;
     font-weight: 500;
     line-height: 22px;
-    margin: 3px;
+    margin: 3px 6px 3px 0;
     padding: 0 10px;
     white-space: nowrap;
 }

--- a/src/components/ItemView.vue
+++ b/src/components/ItemView.vue
@@ -162,12 +162,6 @@ const references = computed(() => parseReferences(item.properties?.references ??
     gap: 5px;
 }
 
-@media (width <= 800px) {
-    .description {
-        flex-direction: column;
-    }
-}
-
 .summary {
     flex: 10 10 auto;
 }
@@ -178,5 +172,15 @@ const references = computed(() => parseReferences(item.properties?.references ??
     height: 300px;
     flex: 1 1 400px;
     margin: 5px 0;
+}
+
+@media (width <= 800px) {
+    .description {
+        flex-direction: column;
+    }
+
+    .map {
+        flex: 1 1 300px;
+    }
 }
 </style>


### PR DESCRIPTION
This PR:
* fixes the vertical spacing around the StacMap on small screens
* removes the unintended indent of the keyword tags