### PR TITLE
Handle text-overflow of item CID

### DIFF
--- a/src/components/PathView.vue
+++ b/src/components/PathView.vue
@@ -35,4 +35,22 @@ div.srcPath {
 div.CID{
     font-family: 'Courier New', Courier, monospace;
 }
+
+@keyframes scrollHint {
+    0% {
+        transform: translateX(0);
+    }
+    50% {
+        transform: translateX(-10px);
+    }
+    100% {
+        transform: translateX(0);
+    }
+}
+
+@media (width <= 585px) {
+    div.CID, div.srcPath {
+        animation: scrollHint .4s;
+    }
+}
 </style>

--- a/src/components/PathView.vue
+++ b/src/components/PathView.vue
@@ -21,7 +21,7 @@ const {src, item_cid} = defineProps<{ src: string, item_cid?: CID }>();
     border-radius: 5px;
     border-color: var(--highlight-bg-color);
     padding: 3px 5px;
-    overflow: hidden;
+    overflow: scroll;
 }
 
 .pathView:has(+ .head) {


### PR DESCRIPTION
This PR:
* allows to scroll CID elements that overflow the screen width
* adds a subtle animation to hint at the scroll