### PR TITLE
Don't use URL.parse, use new URL instead

### DIFF
--- a/src/utils/ipfs/resolve.ts
+++ b/src/utils/ipfs/resolve.ts
@@ -41,7 +41,7 @@ export default async function resolve(helia: Helia, url: string) {
   const name = ipns(helia);
   console.log("helia", helia);
   console.log("name", name);
-  const srcUrl = URL.parse(url);
+  const srcUrl = new URL(url);
   console.log(srcUrl);
   if (srcUrl !== undefined) {
     let root_cid;


### PR DESCRIPTION
new URL does the same as URL.parse (but URL.parse won't throw exceptions). As URL.parse is only available in very recent browsers, we should avoid it for the moment.