### PR TITLE
helia: use full in-browser node by default

### DIFF
--- a/src/plugins/HeliaProvider.ts
+++ b/src/plugins/HeliaProvider.ts
@@ -25,7 +25,7 @@ export default {
   install: (app: App) => {
     const error = shallowRef("");
     const helia = shallowRef();
-    const inBrowser = ref(false);
+    const inBrowser = ref(true);
 
     const load = async (opts: SetupHeliaOpts) => {
       try {


### PR DESCRIPTION
Currently, or main IPFS node is not connected as good as we'd want it.
We can enable more transport mechanisms for fetching data by using a full in-browser IPFS node. This however comes with an increased upfron startup delay.
I'd still propose to activate the inbrowser node for now, and maybe find a way for automatic switchover between the two options in a later PR.