### PR TITLE
Revert "helia: use full in-browser node by default"

### DIFF
--- a/src/plugins/HeliaProvider.ts
+++ b/src/plugins/HeliaProvider.ts
@@ -25,7 +25,7 @@ export default {
   install: (app: App) => {
     const error = shallowRef("");
     const helia = shallowRef();
-    const inBrowser = ref(true);
+    const inBrowser = ref(false);
 
     const load = async (opts: SetupHeliaOpts) => {
       try {


### PR DESCRIPTION
Apparently, this doesn't work so well in quite a few networks...

Reverts orcestra-campaign/ipfsui#61