### PR TITLE
Handle generic dimension when parsing metadata

### DIFF
--- a/src/utils/parseMetadata.ts
+++ b/src/utils/parseMetadata.ts
@@ -404,15 +404,13 @@ function getDatacubeProperties(
     if (varDimensions !== undefined) {
       const attrs = variable.attrs;
       if (varDimensions.length == 1 && varDimensions[0] == varname) {
-        if (hasUnits(attrs)) {
-          if (isTimeVariable(varname, attrs)) {
-            dimensions[varname] = {
-              type: "temporal",
-              unit: attrs.units,
-              ...(hasLongName(attrs) && { description: attrs.long_name }),
-            };
-            continue;
-          }
+        if (hasUnits(attrs) && isTimeVariable(varname, attrs)) {
+          dimensions[varname] = {
+            type: "temporal",
+            unit: attrs.units,
+            ...(hasLongName(attrs) && { description: attrs.long_name }),
+          };
+          continue;
         } else if (hasAxis(attrs)) {
           const axis = attrs.axis.toLowerCase();
           if (["x", "y", "z"].includes(axis)) {
@@ -424,6 +422,13 @@ function getDatacubeProperties(
             };
             continue;
           }
+        } else {
+          dimensions[varname] = {
+            type: "unknown",
+            ...(hasUnits(attrs) && { unit: attrs.units }),
+            ...(hasLongName(attrs) && { description: attrs.long_name }),
+          };
+          continue;
         }
       } else {
         variables[varname] = {

--- a/src/utils/parseMetadata.ts
+++ b/src/utils/parseMetadata.ts
@@ -413,8 +413,7 @@ function getDatacubeProperties(
             };
             continue;
           }
-        }
-        if (hasAxis(attrs)) {
+        } else if (hasAxis(attrs)) {
           const axis = attrs.axis.toLowerCase();
           if (["x", "y", "z"].includes(axis)) {
             dimensions[varname] = {

--- a/src/utils/stac.ts
+++ b/src/utils/stac.ts
@@ -33,12 +33,18 @@ interface _Contact { // see: https://github.com/stac-extensions/contacts?tab=rea
 
 export type Contact = RequireAtLeastOne<_Contact, "name" | "organization">;
 
-export interface Dimension {
-  type: string;
-  axis?: "x" | "y" | "z";
-  description?: string;
-  unit?: string;
-}
+export type Dimension =
+  | {
+    type: "spatial";
+    axis: "x" | "y" | "z";
+    description?: string;
+    unit?: string;
+  }
+  | {
+    type: Exclude<string, "spatial">;
+    description?: string;
+    unit?: string;
+  };
 
 export interface Variable {
   dimensions: string[];


### PR DESCRIPTION
This PR makes the detection of dataset dimensions more robust. The new implementation handles cases in which the `axis` attribute is not set

The datacube dimension `type` in those cases is set to `"unknown"`.