### PR TITLE
Make navbar sticky

### DIFF
--- a/src/components/DSContainer.vue
+++ b/src/components/DSContainer.vue
@@ -61,7 +61,9 @@ watch([() => props.src, heliaProvider?.loading], update);
 </script>
 
 <template>
-    <Nav />
+    <div class="navbar">
+        <Nav />
+    </div>
     <PathView v-if="metadata?.src" :src="metadata?.src as string" :item_cid="metadata?.item_cid" />
     <ItemView v-if="stac_item" :item="stac_item" />
     <Animation v-else />

--- a/src/components/DSIndex.vue
+++ b/src/components/DSIndex.vue
@@ -47,7 +47,7 @@ watchEffect(() => {
 </script>
 
 <template>
-    <div>
+    <div class="navbar">
         <Nav />
         <SearchBox v-model="filter" />
     </div>

--- a/src/style.css
+++ b/src/style.css
@@ -170,3 +170,10 @@ a:hover {
     color: var(--orcestra-blue-light);
   }
 }
+
+.navbar {
+  position: sticky;
+  top: 0;
+  background-color: var(--bg-color);
+  z-index: 10000;
+}


### PR DESCRIPTION
This PR makes the navbar (brand + search bar) stick to the top of the screen, while the body content can scroll behind.