### PR TITLE
Make the boxes in the dataset index clickable

### DIFF
--- a/packages/ui/src/components/DSIndex.vue
+++ b/packages/ui/src/components/DSIndex.vue
@@ -63,10 +63,14 @@ watchEffect(() => {
         </div>
     </div>
     <div class="search_results">
-        <ul class="stac_listing">
-            <li v-for="item of filteredIndex">
-                <a :href="'#/ds/' + item.assets.data.href">{{ item.properties?.title ?? item.assets.data.href }}</a>
-                <ul class="authors"><li v-for="contact in item.properties?.contacts">{{ contact.name }}</li></ul>
+        <ul class="stac_listing" v-for="item of filteredIndex">
+            <li class="stac_listing">
+                <a :href="'#/ds/' + item.assets.data.href">
+                <div>
+                    {{ item.properties?.title ?? item.assets.data.href }}
+                    <ul class="authors"><li v-for="contact in item.properties?.contacts">{{ contact.name }}</li></ul>
+                </div>
+                </a>
             </li>
         </ul>
     </div>

--- a/packages/ui/src/components/DSIndex.vue
+++ b/packages/ui/src/components/DSIndex.vue
@@ -67,7 +67,7 @@ watchEffect(() => {
             <li class="stac_listing">
                 <a :href="'#/ds/' + item.assets.data.href">
                 <div>
-                    {{ item.properties?.title ?? item.assets.data.href }}
+                    <div class="title">{{ item.properties?.title ?? item.assets.data.href }}</div>
                     <ul class="authors"><li v-for="contact in item.properties?.contacts">{{ contact.name }}</li></ul>
                 </div>
                 </a>
@@ -78,10 +78,6 @@ watchEffect(() => {
 
 <style scoped>
 
-a {
-    font-weight: 700;
-}
-
 ul {
   list-style-type: none;
   margin: 0;
@@ -90,19 +86,27 @@ ul {
 
 ul.stac_listing > li {
     display: block;
-
-    border-style: solid;
-    border-color: var(--fg-color);
-    border-width: 1px;
+    outline: 1px solid var(--fg-color);
+    outline-offset: -1px;
     border-radius: 5px;
     margin: 5px;
-    padding: 5px;
+    padding: 6px;
+}
+
+ul.stac_listing > li:hover {
+    outline: 2px solid var(--orcestra-yellow);
+}
+
+.title {
+    font-weight: 700;
 }
 
 ul.authors > li {
     display: inline-block;
     margin: 0 .1em;
     font-size: smaller;
+    font-weight: 400;
+    color: var(--fg-color);
 }
 
 ul.authors > li:nth-last-child(n + 3)::after  {


### PR DESCRIPTION
This PR
* makes the enitre boxes on the landing page (dataset index) clickable
* the CSS is adjusted to maintain the same behaviour for the text inside the boxes (i.e. they still behave like text links) but adds a yellow outline when hovering