### PR TITLE
add DC.identifier meta tag on landing pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "1.0.0",
       "workspaces": [
         "packages/*"
-      ]
+      ],
+      "dependencies": {
+        "@unhead/vue": "^2.0.19"
+      }
     },
     "node_modules/@achingbrain/http-parser-js": {
       "version": "0.5.9",
@@ -3345,6 +3348,22 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@unhead/vue": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.0.19.tgz",
+      "integrity": "sha512-7BYjHfOaoZ9+ARJkT10Q2TjnTUqDXmMpfakIAsD/hXiuff1oqWg1xeXT5+MomhNcC15HbiABpbbBmITLSHxdKg==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^5.5.3",
+        "unhead": "2.0.19"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": ">=3.5.18"
+      }
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
@@ -5721,6 +5740,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
     },
     "node_modules/http-cookie-agent": {
       "version": "6.0.8",
@@ -9998,6 +10023,18 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
       "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "license": "MIT"
+    },
+    "node_modules/unhead": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.0.19.tgz",
+      "integrity": "sha512-gEEjkV11Aj+rBnY6wnRfsFtF2RxKOLaPN4i+Gx3UhBxnszvV6ApSNZbGk7WKyy/lErQ6ekPN63qdFL7sa1leow==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^5.5.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "@unhead/vue": "^2.0.19"
+  }
 }

--- a/packages/ui/src/components/ItemView.vue
+++ b/packages/ui/src/components/ItemView.vue
@@ -4,6 +4,7 @@ import { VMarkdownView } from 'vue3-markdown'
 import 'vue3-markdown/dist/vue3-markdown.css'
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { useHead } from '@unhead/vue';
 
 import License from './License.vue';
 import VarTable from './VarTable.vue';
@@ -78,6 +79,21 @@ function createCitation(item: StacItem): string {
   return `${authors}. (${year}). ${title}. ${url}`;
 }
 const citation = computed(() => createCitation(item));
+
+useHead({
+  link: [
+    {
+      rel: "schema.DC",
+      href: "http://purl.org/dc/elements/1.1/",
+    },
+  ],
+  meta: [
+    {
+      name: "DC.identifier",
+      content: item.assets.data.href, // TODO: replace with DOI if available
+    },
+  ],
+})
 
 </script>
 

--- a/packages/ui/src/main.ts
+++ b/packages/ui/src/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from "vue";
 import "./style.css";
 import App from "./App.vue";
+import { createHead } from '@unhead/vue/client';
 
 import { routes } from "./routes.ts";
 import { createRouter, createWebHashHistory } from "vue-router";
@@ -17,4 +18,7 @@ const router = createRouter({
   routes,
 });
 
-createApp(App).use(HeliaProvider).use(router).mount("#app");
+
+const head = createHead();
+
+createApp(App).use(HeliaProvider).use(router).use(head).mount("#app");


### PR DESCRIPTION
This change adds a meta tag to the landing page, as suggested by the [DataCite docs](https://support.datacite.org/docs/landing-pages#the-doi-should-be-appropriately-tagged-so-that-machines-can-read-it).