### PR TITLE
Filter list of potential providers using an exclude list

### DIFF
--- a/packages/ui/src/components/DSContainer.vue
+++ b/packages/ui/src/components/DSContainer.vue
@@ -75,6 +75,22 @@ function parseProvider(provider: Provider): string | undefined {
 const updateProviders = async() => {
   if (metadata.value?.item_cid) {
     for await (const provider of heliaProvider.helia.value.routing.findProviders(metadata.value?.item_cid)) {
+      // Exclude peers by multiaddr pattern
+      const excludeAddrPatterns = [
+        /127\.0\.0\.1/,
+        /localhost/,
+        /ipfs\.io/,
+        /dweb\.link/,
+        /trustless-gateway\.link/,
+      ]
+
+      const addrs = provider.multiaddrs?.map(a => a.toString()) ?? []
+      const matchesExcludedAddr = addrs.some(addr =>
+        excludeAddrPatterns.some(pattern => pattern.test(addr))
+      )
+
+      if (matchesExcludedAddr) continue
+
       providers.value = [...providers.value, provider];
     }
   }


### PR DESCRIPTION
A list of potential providers is shown at the bottom of each dataset landing page.
However, the term "provider" is somewhat ambiguous. IPFS (and Helia) view it as a purely technical term referring to "nodes that can deliver the data", whereas we view it as "nodes that store/pin the data". The most obvious difference between these two definitions are the local and public gateways. Often, both are able to deliver data without pinning it.

This PR defines an exclusion list to prevent those on it from being shown in the list of data providers on the landing page.