### PR TITLE
Add extra keywords for deprecated BOW-TIE identifier

### DIFF
--- a/packages/utils/src/parseMetadata.ts
+++ b/packages/utils/src/parseMetadata.ts
@@ -565,8 +565,9 @@ function parseCommaList(cs_list: string | undefined): string[] | undefined {
 }
 
 function missionKeywords(mission: string | undefined): string[] {
-  if (!mission || !/\bBOW[-\s]?TIE\b/i.test(mission)) return [];
-  return ["BOWTIE", "M203"];
+  if (!mission) return [];
+  if (/\bBOW[-\s]?TIE\b/i.test(mission)) return ["BOWTIE", "M203"];
+  return [];
 }
 
 export function parseManualMetadata(

--- a/packages/utils/src/parseMetadata.ts
+++ b/packages/utils/src/parseMetadata.ts
@@ -564,6 +564,11 @@ function parseCommaList(cs_list: string | undefined): string[] | undefined {
   return list.map((item) => item.replace(/__COMMA_PLACEHOLDER__/g, ","));
 }
 
+function missionKeywords(mission: string | undefined): string[] {
+  if (!mission || !/\bBOW[-\s]?TIE\b/i.test(mission)) return [];
+  return ["BOWTIE", "M203"];
+}
+
 export function parseManualMetadata(
   manual_metadata: ManualMetadata, srcinfo: DatasetSrc
 ): StacItem {
@@ -576,7 +581,7 @@ export function parseManualMetadata(
   const properties: Properties = {
       title: manual_metadata.attributes?.title,
       description: manual_metadata.attributes?.summary,
-      keywords: parseCommaList(manual_metadata.attributes?.keywords),
+      keywords: [...(parseCommaList(manual_metadata.attributes?.keywords) ?? []), ...missionKeywords(manual_metadata.attributes?.project)],
       license: manual_metadata.attributes?.license,
       references: parseCommaList(manual_metadata.attributes?.references),
       platform: manual_metadata.attributes?.platform,
@@ -639,7 +644,7 @@ export default async function* parseMetadata(
   const properties: Properties = {
     title: ds.attrs?.title,
     description: ds.attrs?.summary,
-    keywords: parseCommaList(ds.attrs?.keywords),
+    keywords: [...(parseCommaList(ds.attrs?.keywords) ?? []), ...missionKeywords(ds.attrs?.project)],
     license: ds.attrs?.license,
     references: parseCommaList(ds.attrs?.references),
     platform: ds.attrs?.platform,


### PR DESCRIPTION
In https://github.com/orcestra-campaign/book/pull/637 the mission identifier `BOW-TIE` is replaced with `BOWTIE`, which despite our attribute convention seems to have won the race in literature 🤷‍♂️ 

This PR adds a small helper function which, for all STAC items which `BOWTIE` or `BOW-TIE` mission will add `BOWTIE` and `M203` to the list of keywords. The goal is to increase retrievability for users.

The infrastructure would also allow to add keywords for other missions if wanted, e.g. `HALO` for all `PERCUSION` datasets.